### PR TITLE
Use local dockerized API for tests (PS-919)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,34 +12,58 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
+      - uses: azure/docker-login@v1
         with:
-          php-version: '7.4'
-          tools: composer
-          extensions: json
+          login-server: keboola.azurecr.io
+          username: ${{ secrets.ACR_PULL_USERNAME }}
+          password: ${{ secrets.ACR_PULL_PASSWORD }}
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - run: docker pull localstack/localstack
+      - run: docker pull waisbrot/wait
+      - run: docker pull keboola.azurecr.io/sandboxes-api
+      - run: docker build -t keboola/sandboxes-api-php-client .
 
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist
-
+      - run: |
+          docker run -d --rm --network host -p4569:4569 \
+          -e SERVICES=dynamodb \
+          -e DEBUG=1 \
+          localstack/localstack
+      - run: |
+          docker run --rm --network host \
+          -e TARGETS=localhost:4569 \
+          -e TIMEOUT=60 \
+          waisbrot/wait
+      - run: |
+          docker run -d --rm --network host -p8080:8080 \
+          -e AWS_ACCESS_KEY_ID=accessKey \
+          -e AWS_SECRET_ACCESS_KEY=secretKey \
+          -e REGION=local \
+          -e DYNAMO_ENDPOINT=http://localhost:4569 \
+          -e DYNAMO_TABLE_RUNS=runs \
+          -e DYNAMO_TABLE_SANDBOXES=sandboxes \
+          -e KBC_URL=https://connection.keboola.com \
+          -e API_URL=http://localhost:8080 \
+          -e STAGE=dev \
+          keboola.azurecr.io/sandboxes-api yarn start
+      - run: |
+          docker run --rm --network host \
+          -e TARGETS=localhost:8080 \
+          -e TIMEOUT=60 \
+          waisbrot/wait
       - name: Lint code
-        run: composer cs
-
+        run: |
+          docker run --rm --network host \
+          keboola/sandboxes-api-php-client composer cs
       - name: Run tests
-        run: composer test
-        env:
-          API_URL: https://rl61yqksc4.execute-api.us-east-1.amazonaws.com/test/
-          KBC_URL: https://connection.keboola.com
-          KBC_STORAGE_TOKEN: ${{ secrets.KBC_STORAGE_TOKEN }}
-          KBC_MANAGE_TOKEN: ${{ secrets.KBC_MANAGE_TOKEN }}
+        run: |
+          docker run --rm --network host \
+          -e API_URL=http://localhost:8080 \
+          -e AWS_ACCESS_KEY_ID=accessKey \
+          -e AWS_SECRET_ACCESS_KEY=secretKey \
+          -e DYNAMO_ENDPOINT=http://localhost:4569 \
+          -e DYNAMO_TABLE_SANDBOXES=sandboxes \
+          -e DYNAMO_TABLE_RUNS=runs \
+          -e KBC_URL=https://connection.keboola.com \
+          -e "KBC_STORAGE_TOKEN=${{ secrets.KBC_STORAGE_TOKEN }}" \
+          -e "KBC_MANAGE_TOKEN=${{ secrets.KBC_MANAGE_TOKEN }}" \
+          keboola/sandboxes-api-php-client composer test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM php:7.4-cli
+
+ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
+ARG DEBIAN_FRONTEND=noninteractive
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_PROCESS_TIMEOUT 3600
+
+WORKDIR /code/
+
+COPY docker/composer-install.sh /tmp/composer-install.sh
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        locales \
+        unzip \
+	&& rm -r /var/lib/apt/lists/* \
+	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
+	&& locale-gen \
+	&& chmod +x /tmp/composer-install.sh \
+	&& /tmp/composer-install.sh
+
+ENV LANGUAGE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+## Composer - deps always cached unless changed
+# First copy only composer files
+COPY composer.* /code/
+# Download dependencies, but don't run scripts or init autoloaders as the app is missing
+RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
+# copy rest of the app
+COPY . /code/
+# run normal composer - all deps are cached already
+RUN composer install $COMPOSER_FLAGS

--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ require 'vendor/autoload.php';
 ```
 
 Read more in [Composer documentation](http://getcomposer.org/doc/01-basic-usage.md)
+
+
+## CI
+
+CI is running in GitHub and requires setup of these secrets:
+- `ACR_PULL_USERNAME` - docker credentials for Azure service principal allowed pulling `keboola.azurecr.io/sandboxes-api` (see <https://github.com/keboola/sandboxes#acr-access-from-travis>)
+- `ACR_PULL_PASSWORD`
+- `KBC_STORAGE_TOKEN` - a Storage token working for connection.keboola.com stack
+- `KBC_MANAGE_TOKEN` - Manage token with `provisioning:manage` scope 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/validator": "^4.2"
     },
     "require-dev": {
+        "aws/aws-sdk-php": "^3.151",
         "keboola/coding-standard": "^8.0",
         "keboola/storage-api-client": "^10.6.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '2'
+services:
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: keboola/sandboxes-api-php-client
+    command: composer test
+    volumes:
+      - ./:/code
+      - ./data:/data
+    environment:
+      - API_URL=http://sandboxes-api:8080
+      - AWS_ACCESS_KEY_ID=accessKey
+      - AWS_SECRET_ACCESS_KEY=secretKey
+      - DYNAMO_ENDPOINT=http://localstack:4569
+      - DYNAMO_TABLE_SANDBOXES=sandboxes
+      - DYNAMO_TABLE_RUNS=runs
+      - KBC_URL=https://connection.keboola.com
+      - KBC_STORAGE_TOKEN
+      - KBC_MANAGE_TOKEN
+    depends_on:
+      - sandboxes-api
+
+  sandboxes-api:
+    image: keboola.azurecr.io/sandboxes-api
+    command: bash -c "yarn start"
+    ports:
+      - 8080:8080
+    environment:
+      - AWS_ACCESS_KEY_ID=accessKey
+      - AWS_SECRET_ACCESS_KEY=secretKey
+      - REGION=local
+      - DYNAMO_ENDPOINT=http://localstack:4569
+      - DYNAMO_TABLE_SANDBOXES=sandboxes
+      - DYNAMO_TABLE_RUNS=runs
+      - KBC_URL=https://connection.keboola.com
+      - API_URL=http://sandboxes-api:8080
+      - STAGE=dev
+    depends_on:
+      - localstack
+
+  localstack:
+    image: localstack/localstack
+    environment:
+      - SERVICES=dynamodb
+      - DEBUG=1
+

--- a/docker/composer-install.sh
+++ b/docker/composer-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE=$(curl -s https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet --install-dir=/usr/local/bin/ --filename=composer
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,6 +29,55 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 ->setConfigurationId($this->configurationId)
                 ->setName($this->configurationId)
         );
+
+        $sdk = new \Aws\Sdk([
+            'endpoint'   => getenv('DYNAMO_ENDPOINT'),
+            'region'   => 'local',
+            'version'  => 'latest',
+        ]);
+        $dynamodb = $sdk->createDynamoDb();
+        try {
+            $dynamodb->createTable([
+                'TableName' => getenv('DYNAMO_TABLE_SANDBOXES'),
+                'KeySchema' => [
+                    ['AttributeName' => 'projectId', 'KeyType' => 'HASH'],
+                    ['AttributeName' => 'id', 'KeyType' => 'RANGE'],
+                ],
+                'AttributeDefinitions' => [
+                    ['AttributeName' => 'projectId', 'AttributeType' => 'S'],
+                    ['AttributeName' => 'id', 'AttributeType' => 'S'],
+                ],
+                'ProvisionedThroughput' => [
+                    'ReadCapacityUnits' => 10,
+                    'WriteCapacityUnits' => 10,
+                ],
+            ]);
+        } catch (\Aws\DynamoDb\Exception\DynamoDbException $e) {
+            if ($e->getAwsErrorCode() !== 'ResourceInUseException') {
+                throw $e;
+            }
+        }
+        try {
+            $dynamodb->createTable([
+                'TableName' => getenv('DYNAMO_TABLE_RUNS'),
+                'KeySchema' => [
+                    ['AttributeName' => 'sandboxId', 'KeyType' => 'HASH'],
+                    ['AttributeName' => 'startTimestamp', 'KeyType' => 'RANGE'],
+                ],
+                'AttributeDefinitions' => [
+                    ['AttributeName' => 'sandboxId', 'AttributeType' => 'S'],
+                    ['AttributeName' => 'startTimestamp', 'AttributeType' => 'S'],
+                ],
+                'ProvisionedThroughput' => [
+                    'ReadCapacityUnits' => 10,
+                    'WriteCapacityUnits' => 10,
+                ],
+            ]);
+        } catch (\Aws\DynamoDb\Exception\DynamoDbException $e) {
+            if ($e->getAwsErrorCode() !== 'ResourceInUseException') {
+                throw $e;
+            }
+        }
     }
 
     public function testClient(): void


### PR DESCRIPTION
Basically, the CI setup is taken from the component (https://github.com/keboola/sandboxes/blob/c0d11fcddc8282932d9fe97b01400d30e32c454e/.travis.yml#L77-L128). The tests are run in docker image with linked docker containers with Dynamo and the API. Dynamo has to be initialized first and that's taken again from component tests (https://github.com/keboola/sandboxes/blob/c0d11fcddc8282932d9fe97b01400d30e32c454e/tests/phpunit/App/AbstractAppTest.php#L34-L81).

