### PR TITLE
Support activate and deactivate operations (PS-859)

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -40,12 +40,30 @@ class Client extends AbstractClient
         }
     }
 
-    public function deactivate(string $id): void
+    public function deactivate(string $id): Sandbox
     {
         try {
-            $this->sendRequest(new Request('DELETE', "sandboxes/{$id}"));
+            return new Sandbox($this->sendRequest(new Request('POST', "sandboxes/{$id}/deactivate", [], '{}')));
         } catch (GuzzleException $guzzleException) {
             throw new Exception('Error deactivating sandbox', $guzzleException->getCode(), $guzzleException);
+        }
+    }
+
+    public function activate(string $id): Sandbox
+    {
+        try {
+            return new Sandbox($this->sendRequest(new Request('POST', "sandboxes/{$id}/activate", [], '{}')));
+        } catch (GuzzleException $guzzleException) {
+            throw new Exception('Error activating sandbox', $guzzleException->getCode(), $guzzleException);
+        }
+    }
+
+    public function delete(string $id): Sandbox
+    {
+        try {
+            return new Sandbox($this->sendRequest(new Request('DELETE', "sandboxes/{$id}")));
+        } catch (GuzzleException $guzzleException) {
+            throw new Exception('Error deleting sandbox', $guzzleException->getCode(), $guzzleException);
         }
     }
 

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -32,12 +32,12 @@ class ManageClient extends AbstractClient
         );
     }
 
-    public function delete(string $id): void
+    public function deactivate(string $id): void
     {
         try {
             $this->sendRequest(new Request('DELETE', "manage/{$id}"));
         } catch (GuzzleException $guzzleException) {
-            throw new Exception('Error deleting sandbox', $guzzleException->getCode(), $guzzleException);
+            throw new Exception('Error deactivating sandbox', $guzzleException->getCode(), $guzzleException);
         }
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -131,15 +131,21 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($foundInList);
 
         // 5. Deactivate
-        $client->deactivate($sandboxId);
-
-        // 6. Get and check if deactivated
-        $response = $client->get($sandboxId);
+        $response = $client->deactivate($sandboxId);
         $this->assertNotEmpty($response);
         $this->assertFalse($response->getActive());
         $this->assertEmpty($response->getDeletedTimestamp());
 
-        // 7. Find in list of expired sandboxes
+        // 6. Activate
+        $response = $client->activate($sandboxId);
+        $this->assertNotEmpty($response);
+        $this->assertTrue($response->getActive());
+
+        // 7. Set to be expired
+        $sandbox->setExpirationTimestamp(date('c', strtotime('-1 day')));
+        $client->update($sandbox);
+
+        // 8. Find in list of expired sandboxes
         $foundInList = false;
         $response = $manageClient->listExpired();
         foreach ($response as $r) {
@@ -149,12 +155,16 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         }
         $this->assertTrue($foundInList);
 
-        // 8. Delete
-        $manageClient->delete($sandboxId);
+        // 9. Manage deactivate
+        $manageClient->deactivate($sandboxId);
 
-        // 9. Manage get and check if deleted
+        // 10. Manage get and check if deactivated
         $response = $manageClient->get($sandboxId);
         $this->assertNotEmpty($response);
+        $this->assertFalse($response->getActive());
+
+        // 11. Delete
+        $response = $client->delete($sandboxId);
         $this->assertNotEmpty($response->getDeletedTimestamp());
     }
 


### PR DESCRIPTION
- added `activate`
- added `delete`
- changed `deactivate` to do the deactivation instead of previous deleting
- changed manage `delete` to `deactivate`

(Will have to be released as 2.0.0 because of the BC breaks)