### PR TITLE
fix allow preset options.headers in constructor (PS-958)

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -14,7 +14,10 @@ class Client extends AbstractClient
         string $storageToken,
         ?array $options = []
     ) {
-        $options['headers'] = ['X-StorageApi-Token' => $storageToken];
+        if (!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+        $options['headers']['X-StorageApi-Token'] = $storageToken;
         parent::__construct($apiUrl, $options);
     }
 

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -14,7 +14,10 @@ class ManageClient extends AbstractClient
         string $token,
         ?array $options = []
     ) {
-        $options['headers'] = ['X-KBC-ManageApiToken' => $token];
+        if (!isset($options['headers'])) {
+            $options['headers'] = [];
+        }
+        $options['headers']['X-KBC-ManageApiToken'] = $token;
         parent::__construct($apiUrl, $options);
     }
 


### PR DESCRIPTION
So that we can set the run id in the component in the `$options` parameter.