### PR TITLE
Clean up sandbox class constructor (PS-966)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "scripts": {
         "test": "phpunit --bootstrap tests/bootstrap.php --fail-on-warning --stop-on-failure tests",
-        "phpstan": "phpstan analyse ./src ./tests --level=max --no-progress -c phpstan.neon",
+        "phpstan": "phpstan analyse ./src ./tests --level=max --memory-limit=-1 --no-progress -c phpstan.neon",
         "phpcs": "phpcs -n --ignore=vendor --extensions=php .",
         "phpcbf": "phpcbf -n --ignore=vendor --extensions=php .",
         "phplint": "parallel-lint -j 10 --exclude vendor .",

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,7 +26,7 @@ class Client extends AbstractClient
         $jobData = \GuzzleHttp\json_encode($sandbox->toApiRequest());
         $request = new Request('POST', 'sandboxes', [], $jobData);
         try {
-            return new Sandbox($this->sendRequest($request));
+            return Sandbox::fromArray($this->sendRequest($request));
         } catch (GuzzleException $guzzleException) {
             throw new Exception('Error creating sandbox', $guzzleException->getCode(), $guzzleException);
         }
@@ -37,7 +37,7 @@ class Client extends AbstractClient
         $jobData = \GuzzleHttp\json_encode($sandbox->toApiRequest());
         $request = new Request('PUT', "sandboxes/{$sandbox->getId()}", [], $jobData);
         try {
-            return new Sandbox($this->sendRequest($request));
+            return Sandbox::fromArray($this->sendRequest($request));
         } catch (GuzzleException $guzzleException) {
             throw new Exception('Error updating sandbox', $guzzleException->getCode(), $guzzleException);
         }
@@ -46,7 +46,7 @@ class Client extends AbstractClient
     public function deactivate(string $id): Sandbox
     {
         try {
-            return new Sandbox($this->sendRequest(new Request('POST', "sandboxes/{$id}/deactivate", [], '{}')));
+            return Sandbox::fromArray($this->sendRequest(new Request('POST', "sandboxes/{$id}/deactivate", [], '{}')));
         } catch (GuzzleException $guzzleException) {
             throw new Exception('Error deactivating sandbox', $guzzleException->getCode(), $guzzleException);
         }
@@ -55,7 +55,7 @@ class Client extends AbstractClient
     public function activate(string $id): Sandbox
     {
         try {
-            return new Sandbox($this->sendRequest(new Request('POST', "sandboxes/{$id}/activate", [], '{}')));
+            return Sandbox::fromArray($this->sendRequest(new Request('POST', "sandboxes/{$id}/activate", [], '{}')));
         } catch (GuzzleException $guzzleException) {
             throw new Exception('Error activating sandbox', $guzzleException->getCode(), $guzzleException);
         }
@@ -64,7 +64,7 @@ class Client extends AbstractClient
     public function delete(string $id): Sandbox
     {
         try {
-            return new Sandbox($this->sendRequest(new Request('DELETE', "sandboxes/{$id}")));
+            return Sandbox::fromArray($this->sendRequest(new Request('DELETE', "sandboxes/{$id}")));
         } catch (GuzzleException $guzzleException) {
             throw new Exception('Error deleting sandbox', $guzzleException->getCode(), $guzzleException);
         }
@@ -72,7 +72,7 @@ class Client extends AbstractClient
 
     public function get(string $id): Sandbox
     {
-        return new Sandbox(
+        return Sandbox::fromArray(
             $this->sendRequest(new Request('GET', "sandboxes/{$id}"))
         );
     }
@@ -81,7 +81,7 @@ class Client extends AbstractClient
     public function list(): array
     {
         return array_map(function ($s) {
-            return new Sandbox($s);
+            return Sandbox::fromArray($s);
         }, $this->sendRequest(new Request('GET', 'sandboxes')));
     }
 }

--- a/src/Exception/InvalidApiResponseException.php
+++ b/src/Exception/InvalidApiResponseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Keboola\Sandboxes\Api\Exception;
 
 class InvalidApiResponseException extends \Exception

--- a/src/Exception/InvalidApiResponseException.php
+++ b/src/Exception/InvalidApiResponseException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Keboola\Sandboxes\Api\Exception;
+
+class InvalidApiResponseException extends \Exception
+{
+
+}

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -30,7 +30,7 @@ class ManageClient extends AbstractClient
 
     public function get(string $id): Sandbox
     {
-        return new Sandbox(
+        return Sandbox::fromArray(
             $this->sendRequest(new Request('GET', "manage/{$id}"))
         );
     }

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -24,7 +24,7 @@ class ManageClient extends AbstractClient
     public function listExpired(): array
     {
         return array_map(function ($s) {
-            return new Sandbox($s);
+            return Sandbox::fromArray($s);
         }, $this->sendRequest(new Request('GET', 'manage/list/expired')));
     }
 

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -9,65 +9,55 @@ use Keboola\Sandboxes\Api\Exception\InvalidApiResponseException;
 class Sandbox
 {
     public const DEFAULT_EXPIRATION_DAYS = 7;
+    protected const REQUIRED_PROPERTIES = ['id', 'projectId', 'tokenId', 'type', 'active', 'createdTimestamp'];
 
     private string $id;
     private string $projectId;
-    private ?string $tokenId = null;
-    private ?string $configurationId = null;
-    private ?string $physicalId = null;
-
+    private string $tokenId;
     private string $type;
-    private string $size = 'small';
+    private bool $active;
+
+    private string $configurationId;
+    private string $physicalId;
+    private string $size;
 
     private string $user;
-    private ?string $password = null;
-    private ?string $host = null;
-    private ?string $url = null;
+    private string $password;
+    private string $host;
+    private string $url;
 
-    private ?string $imageVersion = null;
-    private ?string $stagingWorkspaceId = null;
-    private ?string $stagingWorkspaceType = null;
-    private ?array $workspaceDetails = [];
-    private ?string $autosaveTokenId = null;
-    private ?array $packages = [];
+    private string $autosaveTokenId;
+    private string $imageVersion;
+    private string $stagingWorkspaceId;
+    private string $stagingWorkspaceType;
+    private array $workspaceDetails;
+    private array $packages;
 
-    private ?bool $active = null;
-    private ?string $createdTimestamp = null;
-    private ?string $updatedTimestamp = null;
-    private ?string $expirationTimestamp = null;
-    private ?string $lastAutosaveTimestamp = null;
-    private ?int $expirationAfterHours = null;
-    private ?string $deletedTimestamp = null;
+    private string $createdTimestamp;
+    private string $updatedTimestamp;
+    private string $expirationTimestamp;
+    private string $lastAutosaveTimestamp;
+    private int $expirationAfterHours;
+    private string $deletedTimestamp;
 
 
     public static function fromArray(array $in): self
     {
-        $sandbox = new Sandbox();
-        if (!isset($in['id'])) {
-            throw new InvalidApiResponseException('Property id is missing from API response');
+        foreach (self::REQUIRED_PROPERTIES as $property) {
+            if (!isset($in[$property])) {
+                throw new InvalidApiResponseException("Property $property is missing from API response");
+            }
         }
-        $sandbox->setId((string) $in['id']);
-        if (!isset($in['projectId'])) {
-            throw new InvalidApiResponseException('Property projectId is missing from API response');
-        }
-        $sandbox->setProjectId((string) $in['projectId']);
-        if (!isset($in['tokenId'])) {
-            throw new InvalidApiResponseException('Property tokenId is missing from API response');
-        }
-        $sandbox->setTokenId((string) $in['tokenId']);
-        if (!isset($in['configurationId'])) {
-            throw new InvalidApiResponseException('Property configurationId is missing from API response');
-        }
-        $sandbox->setConfigurationId((string) $in['configurationId']);
-        if (!isset($in['type'])) {
-            throw new InvalidApiResponseException('Property type is missing from API response');
-        }
-        $sandbox->setType($in['type']);
-        if (!isset($in['active'])) {
-            throw new InvalidApiResponseException('Property active is missing from API response');
-        }
-        $sandbox->setActive($in['active'] ?? false);
 
+        $sandbox = new Sandbox();
+        $sandbox->setId((string) $in['id']);
+        $sandbox->setProjectId((string) $in['projectId']);
+        $sandbox->setTokenId((string) $in['tokenId']);
+        $sandbox->setType($in['type']);
+        $sandbox->setActive($in['active'] ?? false);
+        $sandbox->setCreatedTimestamp($in['createdTimestamp']);
+
+        $sandbox->setConfigurationId(isset($in['configurationId']) ? (string) $in['configurationId'] : '');
         $sandbox->setPhysicalId($in['physicalId'] ?? '');
         $sandbox->setSize($in['size'] ?? '');
         $sandbox->setUser($in['user'] ?? '');
@@ -80,7 +70,6 @@ class Sandbox
         $sandbox->setWorkspaceDetails($in['workspaceDetails'] ?? []);
         $sandbox->setAutosaveTokenId(isset($in['autosaveTokenId']) ? (string) $in['autosaveTokenId'] : '');
         $sandbox->setPackages($in['packages'] ?? []);
-        $sandbox->setCreatedTimestamp($in['createdTimestamp'] ?? '');
         $sandbox->setUpdatedTimestamp($in['updatedTimestamp'] ?? '');
         $sandbox->setExpirationTimestamp($in['expirationTimestamp'] ?? '');
         $sandbox->setLastAutosaveTimestamp($in['lastAutosaveTimestamp'] ?? '');
@@ -430,9 +419,6 @@ class Sandbox
 
     public function setSize(string $size): self
     {
-        if (!in_array($size, ['small', 'medium', 'large'])) {
-            throw new Exception('Unsupported size, use small, medium or large');
-        }
         $this->size = $size;
         return $this;
     }

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -38,87 +38,91 @@ class Sandbox
     private ?int $expirationAfterHours = null;
     private ?string $deletedTimestamp = null;
 
-    public function __construct(?array $sandbox = null)
+
+    public static function fromArray(array $in): self
     {
-        if (!empty($sandbox['id'])) {
-            $this->setId((string) $sandbox['id']);
+        $sandbox = new Sandbox();
+        if (!empty($in['id'])) {
+            $sandbox->setId((string) $in['id']);
         }
-        if (!empty($sandbox['projectId'])) {
-            $this->setProjectId((string) $sandbox['projectId']);
+        if (!empty($in['projectId'])) {
+            $sandbox->setProjectId((string) $in['projectId']);
         }
-        if (!empty($sandbox['tokenId'])) {
-            $this->setTokenId((string) $sandbox['tokenId']);
+        if (!empty($in['tokenId'])) {
+            $sandbox->setTokenId((string) $in['tokenId']);
         }
-        if (!empty($sandbox['configurationId'])) {
-            $this->setConfigurationId((string) $sandbox['configurationId']);
+        if (!empty($in['configurationId'])) {
+            $sandbox->setConfigurationId((string) $in['configurationId']);
         }
-        if (!empty($sandbox['physicalId'])) {
-            $this->setPhysicalId($sandbox['physicalId']);
-        }
-
-        if (!empty($sandbox['type'])) {
-            $this->setType($sandbox['type']);
-        }
-        if (!empty($sandbox['size'])) {
-            $this->setSize($sandbox['size']);
+        if (!empty($in['physicalId'])) {
+            $sandbox->setPhysicalId($in['physicalId']);
         }
 
-        if (!empty($sandbox['user'])) {
-            $this->setUser($sandbox['user']);
+        if (!empty($in['type'])) {
+            $sandbox->setType($in['type']);
         }
-        if (!empty($sandbox['password'])) {
-            $this->setPassword($sandbox['password']);
-        }
-        if (!empty($sandbox['host'])) {
-            $this->setHost($sandbox['host']);
-        }
-        if (!empty($sandbox['url'])) {
-            $this->setUrl($sandbox['url']);
+        if (!empty($in['size'])) {
+            $sandbox->setSize($in['size']);
         }
 
-        if (!empty($sandbox['imageVersion'])) {
-            $this->setImageVersion($sandbox['imageVersion']);
+        if (!empty($in['user'])) {
+            $sandbox->setUser($in['user']);
         }
-        if (!empty($sandbox['mlflow'])) {
-            $this->setMlflow($sandbox['mlflow']);
+        if (!empty($in['password'])) {
+            $sandbox->setPassword($in['password']);
         }
-        if (!empty($sandbox['stagingWorkspaceId'])) {
-            $this->setStagingWorkspaceId((string) $sandbox['stagingWorkspaceId']);
+        if (!empty($in['host'])) {
+            $sandbox->setHost($in['host']);
         }
-        if (!empty($sandbox['stagingWorkspaceType'])) {
-            $this->setStagingWorkspaceType($sandbox['stagingWorkspaceType']);
-        }
-        if (!empty($sandbox['workspaceDetails'])) {
-            $this->setWorkspaceDetails($sandbox['workspaceDetails']);
-        }
-        if (!empty($sandbox['autosaveTokenId'])) {
-            $this->setAutosaveTokenId((string) $sandbox['autosaveTokenId']);
-        }
-        if (!empty($sandbox['packages'])) {
-            $this->setPackages($sandbox['packages']);
+        if (!empty($in['url'])) {
+            $sandbox->setUrl($in['url']);
         }
 
-        if (isset($sandbox['active'])) {
-            $this->setActive($sandbox['active'] ?? false);
+        if (!empty($in['imageVersion'])) {
+            $sandbox->setImageVersion($in['imageVersion']);
         }
-        if (!empty($sandbox['createdTimestamp'])) {
-            $this->setCreatedTimestamp($sandbox['createdTimestamp']);
+        if (!empty($in['mlflow'])) {
+            $sandbox->setMlflow($in['mlflow']);
         }
-        if (!empty($sandbox['updatedTimestamp'])) {
-            $this->setUpdatedTimestamp($sandbox['updatedTimestamp']);
+        if (!empty($in['stagingWorkspaceId'])) {
+            $sandbox->setStagingWorkspaceId((string) $in['stagingWorkspaceId']);
         }
-        if (!empty($sandbox['expirationTimestamp'])) {
-            $this->setExpirationTimestamp($sandbox['expirationTimestamp']);
+        if (!empty($in['stagingWorkspaceType'])) {
+            $sandbox->setStagingWorkspaceType($in['stagingWorkspaceType']);
         }
-        if (!empty($sandbox['lastAutosaveTimestamp'])) {
-            $this->setLastAutosaveTimestamp($sandbox['lastAutosaveTimestamp']);
+        if (!empty($in['workspaceDetails'])) {
+            $sandbox->setWorkspaceDetails($in['workspaceDetails']);
         }
-        if (!empty($sandbox['expirationAfterHours'])) {
-            $this->setExpirationAfterHours($sandbox['expirationAfterHours']);
+        if (!empty($in['autosaveTokenId'])) {
+            $sandbox->setAutosaveTokenId((string) $in['autosaveTokenId']);
         }
-        if (!empty($sandbox['deletedTimestamp'])) {
-            $this->setDeletedTimestamp($sandbox['deletedTimestamp']);
+        if (!empty($in['packages'])) {
+            $sandbox->setPackages($in['packages']);
         }
+
+        if (isset($in['active'])) {
+            $sandbox->setActive($in['active'] ?? false);
+        }
+        if (!empty($in['createdTimestamp'])) {
+            $sandbox->setCreatedTimestamp($in['createdTimestamp']);
+        }
+        if (!empty($in['updatedTimestamp'])) {
+            $sandbox->setUpdatedTimestamp($in['updatedTimestamp']);
+        }
+        if (!empty($in['expirationTimestamp'])) {
+            $sandbox->setExpirationTimestamp($in['expirationTimestamp']);
+        }
+        if (!empty($in['lastAutosaveTimestamp'])) {
+            $sandbox->setLastAutosaveTimestamp($in['lastAutosaveTimestamp']);
+        }
+        if (!empty($in['expirationAfterHours'])) {
+            $sandbox->setExpirationAfterHours($in['expirationAfterHours']);
+        }
+        if (!empty($in['deletedTimestamp'])) {
+            $sandbox->setDeletedTimestamp($in['deletedTimestamp']);
+        }
+
+        return $sandbox;
     }
 
     public function toArray(): array
@@ -485,20 +489,5 @@ class Sandbox
     public function getSize(): string
     {
         return $this->size;
-    }
-
-    public static function createPassword(int $length = 16): string
-    {
-        $chars = array('abcdefghijkmnopqrstuvwxyz', 'ABCDEFGHIJKMNOPQRSTUVWXYZ', '0234567890234567890234567');
-        srand((int) microtime() * 1000000);
-        $i = 0;
-        $pass = '';
-        while ($i <= $length - 1) {
-            $num = rand() % 25;
-            $tmp = substr($chars[$i % 3], $num, 1);
-            $pass = $pass . $tmp;
-            $i++;
-        }
-        return $pass;
     }
 }

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\Sandboxes\Api;
 
+use Keboola\Sandboxes\Api\Exception\InvalidApiResponseException;
+
 class Sandbox
 {
     public const DEFAULT_EXPIRATION_DAYS = 7;
@@ -23,7 +25,6 @@ class Sandbox
     private ?string $url = null;
 
     private ?string $imageVersion = null;
-    private bool $mlflow = false;
     private ?string $stagingWorkspaceId = null;
     private ?string $stagingWorkspaceType = null;
     private ?array $workspaceDetails = [];
@@ -42,85 +43,49 @@ class Sandbox
     public static function fromArray(array $in): self
     {
         $sandbox = new Sandbox();
-        if (!empty($in['id'])) {
-            $sandbox->setId((string) $in['id']);
+        if (!isset($in['id'])) {
+            throw new InvalidApiResponseException('Property id is missing from API response');
         }
-        if (!empty($in['projectId'])) {
-            $sandbox->setProjectId((string) $in['projectId']);
+        $sandbox->setId((string) $in['id']);
+        if (!isset($in['projectId'])) {
+            throw new InvalidApiResponseException('Property projectId is missing from API response');
         }
-        if (!empty($in['tokenId'])) {
-            $sandbox->setTokenId((string) $in['tokenId']);
+        $sandbox->setProjectId((string) $in['projectId']);
+        if (!isset($in['tokenId'])) {
+            throw new InvalidApiResponseException('Property tokenId is missing from API response');
         }
-        if (!empty($in['configurationId'])) {
-            $sandbox->setConfigurationId((string) $in['configurationId']);
+        $sandbox->setTokenId((string) $in['tokenId']);
+        if (!isset($in['configurationId'])) {
+            throw new InvalidApiResponseException('Property configurationId is missing from API response');
         }
-        if (!empty($in['physicalId'])) {
-            $sandbox->setPhysicalId($in['physicalId']);
+        $sandbox->setConfigurationId((string) $in['configurationId']);
+        if (!isset($in['type'])) {
+            throw new InvalidApiResponseException('Property type is missing from API response');
         }
+        $sandbox->setType($in['type']);
+        if (!isset($in['active'])) {
+            throw new InvalidApiResponseException('Property active is missing from API response');
+        }
+        $sandbox->setActive($in['active'] ?? false);
 
-        if (!empty($in['type'])) {
-            $sandbox->setType($in['type']);
-        }
-        if (!empty($in['size'])) {
-            $sandbox->setSize($in['size']);
-        }
-
-        if (!empty($in['user'])) {
-            $sandbox->setUser($in['user']);
-        }
-        if (!empty($in['password'])) {
-            $sandbox->setPassword($in['password']);
-        }
-        if (!empty($in['host'])) {
-            $sandbox->setHost($in['host']);
-        }
-        if (!empty($in['url'])) {
-            $sandbox->setUrl($in['url']);
-        }
-
-        if (!empty($in['imageVersion'])) {
-            $sandbox->setImageVersion($in['imageVersion']);
-        }
-        if (!empty($in['mlflow'])) {
-            $sandbox->setMlflow($in['mlflow']);
-        }
-        if (!empty($in['stagingWorkspaceId'])) {
-            $sandbox->setStagingWorkspaceId((string) $in['stagingWorkspaceId']);
-        }
-        if (!empty($in['stagingWorkspaceType'])) {
-            $sandbox->setStagingWorkspaceType($in['stagingWorkspaceType']);
-        }
-        if (!empty($in['workspaceDetails'])) {
-            $sandbox->setWorkspaceDetails($in['workspaceDetails']);
-        }
-        if (!empty($in['autosaveTokenId'])) {
-            $sandbox->setAutosaveTokenId((string) $in['autosaveTokenId']);
-        }
-        if (!empty($in['packages'])) {
-            $sandbox->setPackages($in['packages']);
-        }
-
-        if (isset($in['active'])) {
-            $sandbox->setActive($in['active'] ?? false);
-        }
-        if (!empty($in['createdTimestamp'])) {
-            $sandbox->setCreatedTimestamp($in['createdTimestamp']);
-        }
-        if (!empty($in['updatedTimestamp'])) {
-            $sandbox->setUpdatedTimestamp($in['updatedTimestamp']);
-        }
-        if (!empty($in['expirationTimestamp'])) {
-            $sandbox->setExpirationTimestamp($in['expirationTimestamp']);
-        }
-        if (!empty($in['lastAutosaveTimestamp'])) {
-            $sandbox->setLastAutosaveTimestamp($in['lastAutosaveTimestamp']);
-        }
-        if (!empty($in['expirationAfterHours'])) {
-            $sandbox->setExpirationAfterHours($in['expirationAfterHours']);
-        }
-        if (!empty($in['deletedTimestamp'])) {
-            $sandbox->setDeletedTimestamp($in['deletedTimestamp']);
-        }
+        $sandbox->setPhysicalId($in['physicalId'] ?? '');
+        $sandbox->setSize($in['size'] ?? '');
+        $sandbox->setUser($in['user'] ?? '');
+        $sandbox->setPassword($in['password'] ?? '');
+        $sandbox->setHost($in['host'] ?? '');
+        $sandbox->setUrl($in['url'] ?? '');
+        $sandbox->setImageVersion($in['imageVersion'] ?? '');
+        $sandbox->setStagingWorkspaceId(isset($in['stagingWorkspaceId']) ? (string) $in['stagingWorkspaceId'] : '');
+        $sandbox->setStagingWorkspaceType($in['stagingWorkspaceType'] ?? '');
+        $sandbox->setWorkspaceDetails($in['workspaceDetails'] ?? []);
+        $sandbox->setAutosaveTokenId(isset($in['autosaveTokenId']) ? (string) $in['autosaveTokenId'] : '');
+        $sandbox->setPackages($in['packages'] ?? []);
+        $sandbox->setCreatedTimestamp($in['createdTimestamp'] ?? '');
+        $sandbox->setUpdatedTimestamp($in['updatedTimestamp'] ?? '');
+        $sandbox->setExpirationTimestamp($in['expirationTimestamp'] ?? '');
+        $sandbox->setLastAutosaveTimestamp($in['lastAutosaveTimestamp'] ?? '');
+        $sandbox->setExpirationAfterHours($in['expirationAfterHours'] ?? '');
+        $sandbox->setDeletedTimestamp($in['deletedTimestamp'] ?? '');
 
         return $sandbox;
     }
@@ -160,9 +125,6 @@ class Sandbox
 
         if (!empty($this->imageVersion)) {
             $result['imageVersion'] = $this->imageVersion;
-        }
-        if (!empty($this->mlflow)) {
-            $result['mlflow'] = $this->mlflow;
         }
         if (!empty($this->stagingWorkspaceId)) {
             $result['stagingWorkspaceId'] = $this->stagingWorkspaceId;
@@ -464,17 +426,6 @@ class Sandbox
     public function getId(): string
     {
         return $this->id;
-    }
-
-    public function setMlflow(bool $mlflow): self
-    {
-        $this->mlflow = $mlflow;
-        return $this;
-    }
-
-    public function getMlflow(): bool
-    {
-        return $this->mlflow;
     }
 
     public function setSize(string $size): self

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -84,7 +84,7 @@ class Sandbox
         $sandbox->setUpdatedTimestamp($in['updatedTimestamp'] ?? '');
         $sandbox->setExpirationTimestamp($in['expirationTimestamp'] ?? '');
         $sandbox->setLastAutosaveTimestamp($in['lastAutosaveTimestamp'] ?? '');
-        $sandbox->setExpirationAfterHours($in['expirationAfterHours'] ?? '');
+        $sandbox->setExpirationAfterHours($in['expirationAfterHours'] ?? 0);
         $sandbox->setDeletedTimestamp($in['deletedTimestamp'] ?? '');
 
         return $sandbox;


### PR DESCRIPTION
The setting of object properties in the constructor was done just by the Client classes here to convert the API response to the object so I think it could be just fine to move it all to a static method. 

The only external place using the constructor is here in the Sandboxes component and it doesn't set the properties so no problem: https://github.com/keboola/sandboxes/blob/c72ebe7a165816b8e82db8452cbc735ce42c03c8/src/App.php#L154 (There are a few more in the tests in fact but these can be updated easily.)

(And the `createPassword()` is not used for a long time so I would remove it.)