### PR TITLE
PS-2926 ManageClient::listProjectSandboxes() method

### DIFF
--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -20,6 +20,21 @@ class ManageClient extends AbstractClient
         parent::__construct($apiUrl, $options);
     }
 
+    /**
+     * @return Sandbox[]
+     *
+     * @TODO pagination
+     */
+    public function listProjectSandboxes(string $projectId): array
+    {
+        $response = $this->sendRequest(new Request(
+            'GET',
+            sprintf('manage/projects/%s/sandboxes', urlencode($projectId))
+        ));
+
+        return array_map(fn (array $s) => Sandbox::fromArray($s), $response);
+    }
+
     public function listExpired(): array
     {
         return array_map(function ($s) {

--- a/tests/ManageClientTest.php
+++ b/tests/ManageClientTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Sandboxes\Api\Tests;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Keboola\Sandboxes\Api\ManageClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ManageClientTest extends TestCase
+{
+    public function testListProjectSandboxes(): void
+    {
+        $guzzleHandler = HandlerStack::create(new MockHandler([
+            function (RequestInterface $request): ResponseInterface {
+                self::assertSame('GET', $request->getMethod());
+                self::assertSame('/manage/projects/project1/sandboxes', $request->getUri()->getPath());
+
+                return new Response(200, ['X-Foo' => 'Bar'], (string) json_encode([
+                    [
+                        'id' => '111',
+                        'projectId' => 'project1',
+                        'tokenId' => 'token-id',
+                        'type' => 'python',
+                        'active' => true,
+                        'createdTimestamp' => '2021-12-12T12:00:00Z',
+                    ],
+                    [
+                        'id' => '222',
+                        'projectId' => 'project1',
+                        'tokenId' => 'token-id',
+                        'type' => 'python',
+                        'active' => true,
+                        'createdTimestamp' => '2021-12-12T12:00:00Z',
+                    ],
+                ]));
+            },
+        ]));
+
+        $manageClient = new ManageClient(
+            (string) getenv('API_URL'),
+            (string) getenv('KBC_MANAGE_TOKEN'),
+            ['handler' => $guzzleHandler]
+        );
+
+        $sandboxes = $manageClient->listProjectSandboxes('project1');
+        self::assertCount(2, $sandboxes);
+        self::assertSame('111', $sandboxes[0]->getId());
+        self::assertSame('222', $sandboxes[1]->getId());
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2926
Depends on https://github.com/keboola/sandboxes-api/pull/154

Puvodne jsem to chtel udelat jak klasicky integracni test volat realny `sandboxes-api`. Problem ale byl, ze nemam jak "vyresetovat" jeho stav, takze kdybych zavolal listovani, nevim jake sandboxy tma uz jsou z drivejska. Tak jsem to radeji namockoval.