### PR TITLE
PS-3276 Support Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~6.0|~7.0",
         "psr/log": "^1.1",
         "symfony/validator": "^4.2 !=4.4.33"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.0|~7.0",
         "psr/log": "^1.1",
-        "symfony/validator": "^4.2 !=4.4.33"
+        "symfony/validator": "^4.2 !=4.4.33|^6.0"
     },
     "require-dev": {
         "keboola/coding-standard": "^13.0.0",


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-3276

Allow to install with Guzzle 7 & Symfony 6 Validator so it can be used with Sandboxes Service (PHP 8.1, Symfony 6+). There are not many tests but so far it looks OK.