### PR TITLE
Give MLDeployment::trackingTokenId a default value 

### DIFF
--- a/src/MLDeployment.php
+++ b/src/MLDeployment.php
@@ -19,7 +19,7 @@ class MLDeployment
     private string $createdTimestamp;
     private string $updatedTimestamp;
 
-    private ?string $trackingTokenId;
+    private ?string $trackingTokenId = null;
 
     public static function fromArray(array $in): self
     {

--- a/tests/MLDeploymentTest.php
+++ b/tests/MLDeploymentTest.php
@@ -109,13 +109,15 @@ class MLDeploymentTest extends TestCase
         ];
     }
 
-    public function testSetTrackingTokenId(): void
+    public function testTrackingTokenId(): void
     {
         $mlDeployment = (new MLDeployment())
             ->setId('123')
             ->setProjectId('123')
             ->setTokenId('123');
+
         self::assertArrayNotHasKey('trackingTokenId', $mlDeployment->toArray());
+        self::assertNull($mlDeployment->getTrackingTokenId());
 
         $mlDeployment->setTrackingTokenId('token');
         self::assertEquals('token', $mlDeployment->getTrackingTokenId());
@@ -123,8 +125,8 @@ class MLDeploymentTest extends TestCase
         $mlDeployment->clearTackingTokenId();
         self::assertEquals('', $mlDeployment->getTrackingTokenId());
 
-        self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage(
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
             'Cannot set the trackingTokenId to an empty value, use the clearTrackingTokenId method instead'
         );
         $mlDeployment->setTrackingTokenId('');


### PR DESCRIPTION
Give MLDeployment::trackingTokenId a default value so getTrackingTokenId wouldn't end with uninitialized property access