### PR TITLE
SOX-128 Implement sandboxDelete on ManageClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
     "config": {
         "sort-packages": true,
         "optimize-autoloader": true,
+        "lock": false,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -57,6 +57,12 @@ class ManageClient extends AbstractClient
         return Sandbox::fromArray($this->sendRequest($request));
     }
 
+    public function deleteSandbox(string $sandboxId): void
+    {
+        $request = new Request('DELETE', sprintf('manage/%s', $sandboxId));
+        $this->sendRequest($request);
+    }
+
     public function deactivate(string $id): void
     {
         $this->sendRequest(new Request('POST', "manage/{$id}/deactivate", [], '{}'));

--- a/tests/ManageClientUnitTest.php
+++ b/tests/ManageClientUnitTest.php
@@ -52,4 +52,37 @@ class ManageClientUnitTest extends TestCase
         ));
         self::assertSame('{}', (string) $request->getBody());
     }
+
+    public function testDeleteSandbox(): void
+    {
+        $requestsLog = [];
+
+        $mockedResponses = [
+            new Response(200),
+        ];
+
+        $handlerStack = HandlerStack::create(new MockHandler($mockedResponses));
+        $handlerStack->push(Middleware::history($requestsLog));
+
+        $client = new ManageClient('http://sandboxes-api', 'token', [
+            'handler' => $handlerStack,
+        ]);
+
+        $client->deleteSandbox('sandbox-123');
+
+        self::assertCount(1, $requestsLog);
+
+        $request = $requestsLog[0]['request'];
+        self::assertInstanceOf(Request::class, $request);
+
+        self::assertSame('DELETE', $request->getMethod());
+        self::assertSame('http://sandboxes-api/manage/sandbox-123', Uri::composeComponents(
+            $request->getUri()->getScheme(),
+            $request->getUri()->getHost(),
+            $request->getUri()->getPath(),
+            $request->getUri()->getQuery(),
+            $request->getUri()->getFragment()
+        ));
+        self::assertEmpty((string) $request->getBody());
+    }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SOX-128

API uz mazani sandboxu pres manage API davno podporuje, jen nebylo vytazeny do ManageClienta.