### PR TITLE
Sandbox::getExpirationTimestamp() return type fixup

### DIFF
--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -532,7 +532,7 @@ class Sandbox
         return $this;
     }
 
-    public function getExpirationAfterHours(): ?int
+    public function getExpirationAfterHours(): int
     {
         return $this->expirationAfterHours;
     }


### PR DESCRIPTION
`Sandbox::fromArray()` se upravoval tady

https://github.com/keboola/sandboxes-api-php-client/commit/e5efdb3ac270388eb8c499cd835136a2262bf746#diff-13ebad36f392cf70c46dfa3df6cd7ee23946505c7e424e3b7d5ea0281ae98a72L87

takže bych řekl že nikdy nemůže nastat situace, že `expirationAfterHours` je null