### PR TITLE
Sandbox::getJupyterApiUrl()

### DIFF
--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -740,4 +740,18 @@ class Sandbox
     {
         return !empty($this->getUrl()) && preg_match('/^https:\/\/[^.]+\.hub\./ui', $this->getUrl()) === 1;
     }
+
+    public function getJupyterApiUrl(): ?string
+    {
+        if (!in_array($this->getType(), self::JUPYTER_TYPES)) {
+            return null;
+        }
+
+        // Remove '/lab` suffix from sandbox url
+        $url = preg_replace('/\/lab$/', '', (string) $this->getUrl());
+        if (empty($url) or empty($this->getPassword())) {
+            return null;
+        }
+        return $url;
+    }
 }

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -749,7 +749,7 @@ class Sandbox
 
         // Remove '/lab` suffix from sandbox url
         $url = preg_replace('/\/lab$/', '', (string) $this->getUrl());
-        if (empty($url) or empty($this->getPassword())) {
+        if (empty($url) || empty($this->getPassword())) {
             return null;
         }
         return $url;

--- a/tests/SandboxTest.php
+++ b/tests/SandboxTest.php
@@ -136,4 +136,98 @@ class SandboxTest extends TestCase
             (new Sandbox())->setUrl($url)->usesProxy(),
         );
     }
+
+    public function getJupyterApiUrlReturnsNullIfUrlOrPasswordIsMissingDataProvider(): Generator
+    {
+        yield 'URL is empty' => [
+            'url' => '',
+            'password' => 'password',
+        ];
+        yield 'Password is empty' => [
+            'url' => 'https://sandbox.hub.com/lab',
+            'password' => '',
+        ];
+        yield 'Password is null' => [
+            'url' => 'https://sandbox.hub.com/lab',
+            'password' => null,
+        ];
+    }
+
+    /**
+     * @dataProvider getJupyterApiUrlReturnsNullIfUrlOrPasswordIsMissingDataProvider
+     */
+    public function testGetJupyterApiUrlReturnsNullIfUrlOrPasswordIsMissing(
+        ?string $url,
+        ?string $password,
+    ): void {
+        $sandbox = new Sandbox();
+        $sandbox->setType('python');
+
+        if ($url !== null) {
+            $sandbox->setUrl($url);
+        }
+        if ($password !== null) {
+            $sandbox->setPassword($password);
+        }
+
+        self::assertNull($sandbox->getJupyterApiUrl());
+    }
+
+    public function getJupyterApiUrlReturnsUrlForJupyterTypeSandboxDataProvider(): Generator
+    {
+        yield 'julia' => ['julia'];
+        yield 'python' => ['python'];
+        yield 'python-databricks' => ['python-databricks'];
+        yield 'python-mlflow' => ['python-mlflow'];
+        yield 'python-snowpark' => ['python-snowpark'];
+        yield 'r' => ['r'];
+    }
+
+    /**
+     * @dataProvider getJupyterApiUrlReturnsUrlForJupyterTypeSandboxDataProvider
+     */
+    public function testGetJupyterApiUrlReturnsUrlForJupyterTypeSandbox(
+        string $type,
+    ): void {
+        $sandbox = new Sandbox();
+        $sandbox->setPassword('password');
+        $sandbox->setType($type);
+        $sandbox->setUrl('https://sandbox.hub.com/dummy');
+
+        self::assertSame('https://sandbox.hub.com/dummy', $sandbox->getJupyterApiUrl());
+
+        // Tests if '/lab` suffix will be removed from sandbox url
+        $sandbox = new Sandbox();
+        $sandbox->setPassword('password');
+        $sandbox->setType($type);
+        $sandbox->setUrl('https://sandbox.hub.com/lab');
+
+        self::assertSame('https://sandbox.hub.com', $sandbox->getJupyterApiUrl());
+    }
+
+    public function getJupyterApiUrlReturnsNullForNonJupyterTypeSandboxDataProvider(): Generator
+    {
+        yield 'bigquery' => ['bigquery'];
+        yield 'exasol' => ['exasol'];
+        yield 'redshift' => ['redshift'];
+        yield 'snowflake' => ['snowflake'];
+        yield 'synapse' => ['synapse'];
+        yield 'teradata' => ['teradata'];
+        yield 'test' => ['test'];
+        yield 'streamlit' => ['streamlit'];
+    }
+
+    /**
+     * @dataProvider getJupyterApiUrlReturnsNullForNonJupyterTypeSandboxDataProvider
+     */
+    public function testGetJupyterApiUrlReturnsNullForNonJupyterTypeSandbox(
+        string $type,
+    ): void {
+        $sandbox = new Sandbox();
+        $sandbox->setUrl('https://sandbox.hub.com/lab');
+        $sandbox->setPassword('password');
+        $sandbox->setType($type);
+
+        self::assertNull($sandbox->getJupyterApiUrl());
+    }
 }


### PR DESCRIPTION
Part of https://keboola.atlassian.net/browse/PST-1616

Logiku z 
https://github.com/keboola/sandboxes-garbage-collector/blob/master/src/Task/CleanupExpiredPodsTask.php#L56-L57
a
https://github.com/keboola/sandboxes-garbage-collector/blob/d6fba340a5d7fee571e15e720970603a753de95e/src/JupyterApiClient.php#L42

jsem přesunul do samostatné metody v clientovi.