### PR TITLE
feat: Add support for listing all sandboxes using manage client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Run tests
         run: |
-          docker-compose run tests composer install
-          docker-compose run tests composer ci
+          docker compose run tests composer install
+          docker compose run tests composer ci
       - name: Dump docker logs on failure
         if: failure()
-        run: docker-compose logs
+        run: docker compose logs

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -116,16 +116,4 @@ class ManageClient extends AbstractClient
         $request = new Request('PATCH', "manage/projects/{$project->getId()}", [], $body);
         return Project::fromArray($this->sendRequest($request));
     }
-
-    public function notifyBranchDeleted(string $branchId): void
-    {
-        $this->sendRequest(
-            new Request(
-                'POST',
-                'notify/branch-deleted',
-                [],
-                json_encode(['branchId' => $branchId], JSON_THROW_ON_ERROR),
-            ),
-        );
-    }
 }

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -36,6 +36,21 @@ class ManageClient extends AbstractClient
         return array_map(fn (array $s) => Sandbox::fromArray($s), $response);
     }
 
+    /**
+     * @return Sandbox[]
+     */
+    public function listAll(): iterable
+    {
+        $response = $this->sendRequestWithPagination(new Request(
+            'GET',
+            'manage/list',
+        ));
+
+        foreach ($response as $sandboxData) {
+            yield Sandbox::fromArray($sandboxData);
+        }
+    }
+
     public function listExpired(): array
     {
         return array_map(function ($s) {

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -221,19 +221,6 @@ class ClientFunctionalTest extends DynamoTestCase
             $createdSandbox->getId(),
             array_map(fn(Sandbox $s) => $s->getId(), $branchResponse),
         );
-
-        $notifyClient = new ManageClient(
-            (string) getenv('API_URL'),
-            (string) getenv('KBC_MANAGE_NOTIFY_TOKEN'),
-        );
-        $notifyClient->notifyBranchDeleted('1234');
-        // sleeping here because this request is asyncronous so we wait for the records to be deleted
-        sleep(3);
-        $branchResponse = $this->client->list(ListOptions::create()->setBranchId('1234'));
-        self::assertNotContains(
-            $createdSandbox->getId(),
-            array_map(fn(Sandbox $s) => $s->getId(), $branchResponse),
-        );
     }
 
     public function testCreateSandboxWithSize(): void


### PR DESCRIPTION
Followup na https://github.com/keboola/sandboxes-api/pull/272

Abysme si mohli vyjet vsehcny sandboxy a porovnat si je s apps (kolik nam jich chybi a jestli mezi nima seid data). Mam na testingu ozkouseny, ze listovani funguje.

V mezicase se ze `sandboxes-api` jeste odstranoval branch deleted notification endpoint (https://github.com/keboola/sandboxes-api/pull/267)