### PR TITLE
feat: add Client::updateAutosaveTimestamp()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ concurrency: ci-pipeline
 env:
   KBC_STORAGE_TOKEN: '${{ secrets.KBC_STORAGE_TOKEN }}'
   KBC_MANAGE_TOKEN: '${{ secrets.KBC_MANAGE_TOKEN }}'
-  KBC_MANAGE_NOTIFY_TOKEN: '${{ secrets.KBC_MANAGE_NOTIFY_TOKEN }}'
 
   # Azure
   AZURE_CLIENT_ID: 233328da-9afe-423b-82c1-915d8c539f71

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       KBC_URL: https://connection.keboola.com
       KBC_STORAGE_TOKEN:
       KBC_MANAGE_TOKEN:
-      KBC_MANAGE_NOTIFY_TOKEN:
       DYNAMO_ENDPOINT: http://localstack:4566
       DYNAMO_TABLE_SANDBOXES: sandboxes
       DYNAMO_TABLE_ML_DEPLOYMENTS: ml-deployments

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,6 +35,13 @@ class Client extends AbstractClient
         return Sandbox::fromArray($this->sendRequest($request));
     }
 
+    public function updateAutosaveTimestamp(string $id, string $timestamp): Sandbox
+    {
+        $jobData = json_encode(['lastAutosaveTimestamp' => $timestamp]);
+        $request = new Request('PATCH', "sandboxes/{$id}", [], $jobData);
+        return Sandbox::fromArray($this->sendRequest($request));
+    }
+
     public function deactivate(string $id, bool $skipBillingReport = false): Sandbox
     {
         $query = [];

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -348,6 +348,30 @@ class ClientFunctionalTest extends DynamoTestCase
         self::assertNull($persistentStorage->getK8sStorageClassName());
     }
 
+    public function testUpdateAutosaveTimestamp(): void
+    {
+        // 1. Create sandbox
+        $sandbox = (new Sandbox())
+            ->setType('python')
+            ->setActive(true);
+
+        $createdSandbox = $this->client->create($sandbox);
+        $sandboxId = $createdSandbox->getId();
+        $this->assertNotEmpty($sandboxId);
+
+        // 2. Update autosave timestamp
+        $timestamp = date('c');
+        $updatedSandbox = $this->client->updateAutosaveTimestamp($sandboxId, $timestamp);
+        $this->assertSame($timestamp, $updatedSandbox->getLastAutosaveTimestamp());
+
+        // 3. Verify persistence by getting the sandbox again
+        $retrievedSandbox = $this->client->get($sandboxId);
+        $this->assertSame($timestamp, $retrievedSandbox->getLastAutosaveTimestamp());
+
+        // 4. Clean up
+        $this->client->delete($sandboxId);
+    }
+
     protected function tearDown(): void
     {
         $this->componentsClient->deleteConfiguration('transformation', $this->configurationId);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,7 +26,7 @@ $dotenv = Dotenv::createImmutable(__DIR__ . '/..');
 if (file_exists(__DIR__ . '/../.env')) {
     $dotenv->load();
 }
-$dotenv->required(['API_URL', 'KBC_MANAGE_TOKEN', 'KBC_MANAGE_NOTIFY_TOKEN', 'KBC_STORAGE_TOKEN', 'KBC_URL']);
+$dotenv->required(['API_URL', 'KBC_MANAGE_TOKEN', 'KBC_STORAGE_TOKEN', 'KBC_URL']);
 
 $tokenEnvs = [
     'KBC_STORAGE_TOKEN',
@@ -69,7 +69,6 @@ foreach ($tokenEnvs as $tokenEnv) {
 
 $tokenEnvs = [
     'KBC_MANAGE_TOKEN',
-    'KBC_MANAGE_NOTIFY_TOKEN',
 ];
 
 foreach ($tokenEnvs as $tokenEnv) {


### PR DESCRIPTION
Fixes https://linear.app/keboola/issue/AJDA-1964/sandboxes-api-php-client-add-lightweight-method-for-updating-sandbox

Adds optimized method for updating sandbox autosave timestamps

Full release notes: https://linear.app/keboola/issue/AJDA-1964/sandboxes-api-php-client-add-lightweight-method-for-updating-sandbox#comment-40abd61b